### PR TITLE
added minimal build placeholder

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,19 @@
+elifePipeline {
+    def commit
+
+    node('containers-jenkins-plugin') {
+
+        stage 'Checkout', {
+            checkout scm
+            commit = elifeGitRevision()
+        }
+
+        stage 'Build and run tests', {
+            try {
+                sh "make IMAGE_TAG=${commit} REVISION=${commit} ci-build-and-test"
+            } finally {
+                sh "make ci-clean"
+            }
+        }
+    }
+}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+ci-build-and-test:
+	# TODO
+	echo "build placeholder: IMAGE_TAG=$(IMAGE_TAG)"
+
+ci-clean:
+	# TODO


### PR DESCRIPTION
part of https://github.com/elifesciences/data-pipeline-bigquery-views/issues/10
and https://github.com/elifesciences/issues/issues/5328
and https://github.com/elifesciences/issues/issues/5788

I thought I make a start and maybe you could quickly enable the project in Jenkins? Then I could slowly migrate the code in gap times.

My general plan is to still use the code and keep the views where they are. The Airflow pipeline can then use this code and refer to the views list in GitHub (on a schedule). And the views project itself will continue to update the views on change as it is currently doing.