### PR TITLE
Make view list config a dataclass

### DIFF
--- a/bigquery_views_manager/view_list.py
+++ b/bigquery_views_manager/view_list.py
@@ -1,7 +1,8 @@
+from dataclasses import dataclass
 import logging
 import re
 from pathlib import Path
-from typing import Container, Dict, Iterable, List, Optional, Set, TypeVar, Union
+from typing import Container, Dict, Iterable, List, Optional, Sequence, Set, TypeVar, Union
 from collections import OrderedDict
 
 import yaml
@@ -339,15 +340,9 @@ class ViewConfig:
         }
 
 
+@dataclass(frozen=True)
 class ViewListConfig:
-    def __init__(self, view_config_list: List[ViewConfig]):
-        self.view_config_list = view_config_list
-
-    def __str__(self):
-        return str(self.view_config_list)
-
-    def __repr__(self):
-        return f'{type(self).__name__}({repr(self.view_config_list)})'
+    view_config_list: Sequence[ViewConfig]
 
     def __len__(self):
         return len(self.view_config_list)
@@ -372,7 +367,7 @@ class ViewListConfig:
         return any(view.view_name == view_name for view in self.view_config_list)
 
     def add_view(self, view: ViewConfig) -> 'ViewListConfig':
-        return ViewListConfig(self.view_config_list + [view])
+        return ViewListConfig(list(self.view_config_list) + [view])
 
     def sort_insert_order(self, base_dir: str | Path) -> 'ViewListConfig':
         dummy_dataset = 'dummy_dataset'

--- a/bigquery_views_manager/view_list.py
+++ b/bigquery_views_manager/view_list.py
@@ -243,18 +243,12 @@ class ViewCondition:
         return True
 
 
+@dataclass(frozen=True)
 class ViewConfig:
-    def __init__(
-        self,
-        view_name: str,
-        materialize: Optional[bool] = None,
-        materialize_as: Optional[str] = None,
-        conditions: Optional[List[ViewCondition]] = None
-    ):
-        self.view_name = view_name
-        self.materialize = materialize
-        self.materialize_as = materialize_as
-        self.conditions = conditions or []
+    view_name: str
+    materialize: Optional[bool] = None
+    materialize_as: Optional[str] = None
+    conditions: Optional[List[ViewCondition]] = None
 
     @staticmethod
     def from_value(value: Union[str, dict]) -> 'ViewConfig':
@@ -291,15 +285,6 @@ class ViewConfig:
     def __str__(self):
         return self.view_name
 
-    def __repr__(self):
-        return (
-            type(self).__name__
-            + f'({repr(self.view_name)}'
-            + f', materialize={repr(self.materialize)}'
-            + f', materialize_as={repr(self.materialize_as)}'
-            + f', conditions={repr(self.conditions)})'
-        )
-
     @property
     def resolved_materialize_as(self):
         if self.materialize_as:
@@ -315,6 +300,8 @@ class ViewConfig:
         })
 
     def resolve_conditions(self, condition_value: dict) -> 'ViewConfig':
+        if not self.conditions:
+            return self
         for condition in self.conditions:
             if not condition.is_matching(condition_value):
                 continue

--- a/bigquery_views_manager/view_list.py
+++ b/bigquery_views_manager/view_list.py
@@ -195,14 +195,10 @@ def determine_view_insert_order(
     )
 
 
+@dataclass(frozen=True)
 class ViewCondition:
-    def __init__(
-        self,
-        if_condition: Dict[str, str],
-        materialize_as: Optional[str] = None
-    ):
-        self.if_condition = if_condition
-        self.materialize_as = materialize_as
+    if_condition: Dict[str, str]
+    materialize_as: Optional[str] = None
 
     @staticmethod
     def from_value(value: dict) -> 'ViewCondition':
@@ -218,16 +214,6 @@ class ViewCondition:
         if self.materialize_as is not None:
             value['materialize_as'] = self.materialize_as
         return value
-
-    def __str__(self):
-        return repr(self)
-
-    def __repr__(self):
-        return (
-            type(self).__name__
-            + f'(if_condition={repr(self.if_condition)}'
-            + f', materialize_as={repr(self.materialize_as)})'
-        )
 
     def get_values(self) -> dict:
         return {

--- a/bigquery_views_manager/view_list.py
+++ b/bigquery_views_manager/view_list.py
@@ -248,7 +248,7 @@ class ViewConfig:
     view_name: str
     materialize: Optional[bool] = None
     materialize_as: Optional[str] = None
-    conditions: List[ViewCondition] = field(default_factory=list)
+    conditions: Sequence[ViewCondition] = field(default_factory=list)
 
     @staticmethod
     def from_value(value: Union[str, dict]) -> 'ViewConfig':

--- a/bigquery_views_manager/view_list.py
+++ b/bigquery_views_manager/view_list.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass, field
 import logging
 import re
 from pathlib import Path
-from typing import Container, Dict, Iterable, List, Optional, Sequence, Set, TypeVar, Union
+from typing import Container, Dict, Iterable, List, Mapping, Optional, Sequence, Set, TypeVar, Union
 from collections import OrderedDict
 
 import yaml
@@ -197,7 +197,7 @@ def determine_view_insert_order(
 
 @dataclass(frozen=True)
 class ViewCondition:
-    if_condition: Dict[str, str]
+    if_condition: Mapping[str, str]
     materialize_as: Optional[str] = None
 
     @staticmethod
@@ -207,8 +207,8 @@ class ViewCondition:
             materialize_as=value.get('materialize_as')
         )
 
-    def to_value(self) -> Dict[str, Union[str, Dict[str, str]]]:
-        value: Dict[str, Union[str, Dict[str, str]]] = {}
+    def to_value(self) -> Dict[str, Union[str, Mapping[str, str]]]:
+        value: Dict[str, Union[str, Mapping[str, str]]] = {}
         if self.if_condition is not None:
             value['if'] = self.if_condition
         if self.materialize_as is not None:

--- a/bigquery_views_manager/view_list.py
+++ b/bigquery_views_manager/view_list.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import logging
 import re
 from pathlib import Path
@@ -248,7 +248,7 @@ class ViewConfig:
     view_name: str
     materialize: Optional[bool] = None
     materialize_as: Optional[str] = None
-    conditions: Optional[List[ViewCondition]] = None
+    conditions: List[ViewCondition] = field(default_factory=list)
 
     @staticmethod
     def from_value(value: Union[str, dict]) -> 'ViewConfig':


### PR DESCRIPTION
related to https://github.com/elifesciences/data-hub-issues/issues/1079

This is to allow equality comparison to work as expected (e.g. in tests)

It also makes implementing `__repr__` unnessary (as it will be implemented by the dataclass).